### PR TITLE
perf: torch backend uses normal-equation + Cholesky

### DIFF
--- a/src/mintpy/ifgram_inversion_gpu.py
+++ b/src/mintpy/ifgram_inversion_gpu.py
@@ -10,12 +10,19 @@
 """GPU-batched solver for the SBAS network inversion.
 
 This module provides ``estimate_timeseries_batch``, an opt-in replacement for
-the per-pixel CPU loop in ``run_ifgram_inversion_patch``. Pixels are solved in
-batches via ``torch.linalg.lstsq`` on CUDA; per-pixel NaN observations are
-masked by zeroing the corresponding row weights, which is mathematically
-equivalent to dropping them from the WLS system.
+the per-pixel CPU loop in ``run_ifgram_inversion_patch``. Pixels are solved
+in batches on CUDA via one of two solvers (selected by the module-private
+``_SOLVER`` constant):
 
-The CPU code path is unchanged when ``backend='cpu'``.
+* ``cholesky`` (default): normal equations + cuSolver-batched Cholesky.
+  Collapses the per-pixel Householder iterations of the QR path into ~5
+  kernel launches per chunk. Rank-deficient pixels are detected and zeroed.
+* ``lstsq``: cuSolver gels (QR), retained for rollback / numerical
+  comparison. Assumes full rank; rank-deficient pixels propagate NaN/Inf.
+
+Per-pixel NaN observations are masked by zeroing the corresponding row
+weights, which is mathematically equivalent to dropping them from the WLS
+system. The CPU code path is unchanged when ``backend='cpu'``.
 """
 
 
@@ -35,6 +42,12 @@ DEFAULT_CHUNK_SIZE = 20000
 
 # safety factor applied to free VRAM when auto-sizing the chunk
 VRAM_SAFETY = 0.4
+
+# Per-chunk solver for the torch backend. 'cholesky' uses normal equations
+# + batched Cholesky (cuSolver-batched), which collapses the per-pixel
+# Householder iterations of 'lstsq' into ~5 kernel launches per chunk.
+# 'lstsq' (cuSolver gels, QR) is retained for rollback / numerical comparison.
+_SOLVER = 'cholesky'
 
 
 def is_backend_available(backend):
@@ -77,6 +90,67 @@ def _auto_chunk_size(num_pair, num_unknown, dtype_bytes=4):
     per_pixel_bytes = 3 * num_pair * num_unknown * dtype_bytes
     n = int(VRAM_SAFETY * free_b / max(per_pixel_bytes, 1))
     return max(1, n)
+
+
+def _solve_lstsq(G_dev, w_dev, y_dev):
+    """Per-pixel weighted least-squares via batched cuSolver gels (QR).
+
+    Args:
+        G_dev: (num_pair, num_unknown) design matrix on GPU.
+        w_dev: (num_pair, n) per-pixel sqrt-weights with NaN rows zeroed.
+        y_dev: (num_pair, n) observations with NaN rows zeroed.
+
+    Returns:
+        (n, num_unknown) per-pixel solution.
+    """
+    A_batch = w_dev.t().unsqueeze(-1) * G_dev.unsqueeze(0)
+    b_batch = (w_dev * y_dev).t().unsqueeze(-1)
+    sol = torch.linalg.lstsq(A_batch, b_batch)
+    return sol.solution.squeeze(-1)
+
+
+def _solve_cholesky(G_dev, w_dev, y_dev):
+    """Per-pixel weighted least-squares via normal equations + batched Cholesky.
+
+    For each pixel k with weighted system Gw_k @ x_k = yw_k where
+    Gw_k = diag(w_k) @ G and yw_k = w_k * y_k, solve the normal equations
+        (Gw_k^T @ Gw_k) x_k = Gw_k^T @ yw_k
+    via cuSolver-batched Cholesky. Compared to the gels (QR) path this
+    collapses ~num_unknown Householder iterations per pixel into a single
+    batched factorization, reducing per-chunk kernel launches from ~1.88M
+    to ~5 (see profile report_profile.md @ cea7573).
+
+    Rank-deficient pixels are detected via cholesky_ex info codes; their
+    factor is replaced with identity and right-hand-side with zeros so the
+    downstream cholesky_solve produces an all-zero solution for those
+    pixels and never propagates NaN/Inf.
+
+    Args:
+        G_dev: (num_pair, num_unknown) design matrix on GPU.
+        w_dev: (num_pair, n) per-pixel sqrt-weights with NaN rows zeroed.
+        y_dev: (num_pair, n) observations with NaN rows zeroed.
+
+    Returns:
+        (n, num_unknown) per-pixel solution.
+    """
+    Gw = w_dev.t().unsqueeze(-1) * G_dev.unsqueeze(0)
+    yw = (w_dev * y_dev).t().unsqueeze(-1)
+    Gw_T = Gw.transpose(-1, -2)
+    N = Gw_T @ Gw
+    r = Gw_T @ yw
+
+    L, info = torch.linalg.cholesky_ex(N)
+    fail_mask = info != 0
+    if fail_mask.any():
+        n_fail = int(fail_mask.sum().item())
+        print(f'WARNING: {n_fail} rank-deficient pixel(s) in chunk; '
+              'setting solution to zero')
+        eye = torch.eye(N.shape[-1], device=L.device, dtype=L.dtype)
+        L = torch.where(fail_mask.view(-1, 1, 1), eye, L)
+        r = torch.where(fail_mask.view(-1, 1, 1), torch.zeros_like(r), r)
+
+    X = torch.cholesky_solve(r, L)
+    return X.squeeze(-1)
 
 
 def estimate_timeseries_batch(
@@ -193,15 +267,13 @@ def estimate_timeseries_batch(
         w_dev = torch.as_tensor(w_chunk, device=device)         # (num_pair, n)
         valid_dev = torch.as_tensor(~nan_mask, device=device)   # (num_pair, n)
 
-        # build batched WLS system
-        # A_batch[k] = diag(w[:, k]) @ G            shape (n, num_pair, num_unknown)
-        # b_batch[k] = w[:, k] * y[:, k]            shape (n, num_pair, 1)
-        A_batch = w_dev.t().unsqueeze(-1) * G_dev.unsqueeze(0)
-        b_batch = (w_dev * y_dev).t().unsqueeze(-1)
-
-        # solve. CUDA driver is fixed to 'gels' (QR, full-rank); rcond is ignored
-        sol = torch.linalg.lstsq(A_batch, b_batch)
-        X_batch = sol.solution.squeeze(-1)                      # (n, num_unknown)
+        # solve per-pixel WLS via the configured solver
+        if _SOLVER == 'cholesky':
+            X_batch = _solve_cholesky(G_dev, w_dev, y_dev)      # (n, num_unknown)
+        elif _SOLVER == 'lstsq':
+            X_batch = _solve_lstsq(G_dev, w_dev, y_dev)         # (n, num_unknown)
+        else:
+            raise ValueError(f'unsupported _SOLVER={_SOLVER!r}')
 
         # inversion-quality: |sum_i exp(j * e_i)| / N (phase coherence)
         # N is the per-pixel count of valid (non-NaN) ifgrams, matching the
@@ -240,7 +312,7 @@ def estimate_timeseries_batch(
         num_inv_obs[c0:c1] = (~nan_mask).sum(axis=0).astype(np.int16)
 
         # free per-chunk tensors before next iteration
-        del A_batch, b_batch, sol, X_batch, y_dev, w_dev, valid_dev
+        del X_batch, y_dev, w_dev, valid_dev
 
         if print_msg:
             chunk_step = max(1, num_chunk // 5)


### PR DESCRIPTION
## Summary
Replace the per-pixel cuSolver `gels` (QR, batched) path inside the torch backend with **normal equations + cuSolver-batched Cholesky** as the new default solver. The old `gels` path is kept as private dead-code (`_solve_lstsq`) selected by the module-private `_SOLVER` constant for rollback / numerical comparison; **no public API or template flag changes**.

Closes step 2 of #4 (PoC + completion run). RMS verification and SSD bench are deferred to a follow-up session.

## Why
The torch.profiler breakdown ([report_profile.md @ cea7573](https://github.com/s-sasaki-earthsea-wizard/mintpy-benchmark/blob/cea7573/report_profile.md)) showed `torch.linalg.lstsq` is **host-launch-overhead bound**, not compute-bound: ~97 Householder iterations per pixel × 19,403 px/chunk = **~1.88M micro-kernel launches per chunk**, with `cudaLaunchKernel` (18.1 s) dominating actual GPU compute (10.4 s) inside a 19.9 s chunk window.

Normal equations + batched Cholesky collapses each chunk to one batched GEMM (`Gw^T @ Gw`) plus one batched factor + solve, **~5 kernel launches per chunk** total. Predicted ~3× chunk-wall improvement (see #4 comment) — to be verified separately on SSD bench.

## What changed
Single-file diff in [src/mintpy/ifgram_inversion_gpu.py](https://github.com/s-sasaki-earthsea-wizard/MintPy/blob/perf/invert-network-cholesky/src/mintpy/ifgram_inversion_gpu.py):
- New `_solve_cholesky(G_dev, w_dev, y_dev)`: forms `Gw = w * G`, `N = Gw^T @ Gw`, `r = Gw^T @ yw`, then `cholesky_ex` → `cholesky_solve`. Rank-deficient pixels are detected via `info != 0` codes and zeroed (with a warning), so the new path is **strictly more robust** than `gels` which would propagate NaN/Inf in that case
- Existing lstsq logic extracted into `_solve_lstsq` (kept for rollback)
- Module-private `_SOLVER = 'cholesky'` constant dispatches inside the chunk loop
- CPU code path, public API of `estimate_timeseries_batch`, CLI flags, and template flags are all unchanged

## Validation (FernandinaSenDT128, RTX 5080)
- [x] All 6 existing pytest cases in `tests/test_ifgram_inversion_gpu.py` pass — numerical equivalence vs scipy.lstsq reference holds within float32 round-off (rms < 1e-4 of signal scale)
- [x] `smallbaselineApp.py --dostep invert_network` completes successfully (exit 0, 157,667 px / 9 chunks, **0 rank-deficient warnings**)
- [x] CPU path unchanged — no edits outside `ifgram_inversion_gpu.py`

## Out of scope (next session)
- RMS comparison: per-pixel `_solve_cholesky` vs `_solve_lstsq` solution diff on FernandinaSenDT128 to verify normal-eq conditioning loss is within tolerance
- SSD bench: end-to-end wall-time vs Phase 1 (`gels` path) for #4 acceptance criterion `≥ 1.3× speedup over the current torch path`
- `benchmark/report_normal_eq.md` filing + Wiki Performance-Benchmarks update
- Decision on whether to delete the `_solve_lstsq` rollback path

Assisted-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>