### PR TITLE
docs: GPU surfaces (gpu.md, installation §2.4) and backend→solver rename

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -88,6 +88,8 @@ Algorithms implemented in the software are described in details at [Yunjun et al
 + [Example data directory](./dir_structure.md)
 + [Example template files](./templates/README.md)
 + [Tutorials in Jupyter Notebook](https://github.com/insarlab/MintPy-tutorial)
++ [Parallel processing with Dask](./dask.md)
++ [GPU acceleration for the `invert_network` step (opt-in PyTorch CUDA solver, partial)](./gpu.md)
 
 ### 4. Contact us
 

--- a/docs/dask.md
+++ b/docs/dask.md
@@ -7,6 +7,8 @@ Most computations in MintPy are operated in either a pixel-by-pixel or a epoch-b
 
 [Here](https://github.com/2gotgrossman/dask-rsmas-presentation) is an entry-level presentation on parallel computing using Dask by David Grossman. Below we brief describe for each cluster/scheduler the required options and recommended best practices.
 
+For GPU acceleration of the `invert_network` step on a single CUDA device — orthogonal to the Dask paths described here — see [gpu.md](./gpu.md).
+
 ## 1. local cluster ##
 
 The parallel processing on a single machine is supported via [`Dask.distributed.LocalCluster`](https://docs.dask.org/en/latest/setup/single-distributed.html#localcluster). This is recommended if you are running MintPy on a local machine with multiple available cores, or on an HPC but wish to allocate only a single node's worth of resources.

--- a/docs/gpu.md
+++ b/docs/gpu.md
@@ -1,0 +1,69 @@
+# Configure GPU acceleration for the network inversion #
+
+The `invert_network` step (in `ifgram_inversion.py`) ships an opt-in GPU solver that batches the per-pixel weighted least-squares inversion as normal-equations + Cholesky on a CUDA device via PyTorch. This is a partial GPU implementation: only `invert_network` is offloaded to the GPU; every other step in `smallbaselineApp.py` continues to run on the CPU. The solver is opt-in — the default `mintpy.networkInversion.solver = auto` resolves to `cpu`, so existing setups are unaffected.
+
+The `torch` solver is orthogonal to Dask parallel processing (see [dask.md](./dask.md)): the former replaces the per-pixel CPU loop with a single batched Cholesky on one CUDA device, the latter distributes that same per-pixel loop across multiple worker processes. The two paths are not currently combined; pick one.
+
+## 1. Setup ##
+
+See [installation.md](./installation.md) section 2.4 for installing the `[gpu]` extras with the matching CUDA wheel index. Selecting `solver = torch` on a host without a visible CUDA device is a hard error (no silent CPU fallback).
+
+## 2. Enable ##
+
+#### 2.1 via command line ####
+
+Run the following in the terminal:
+
+```bash
+ifgram_inversion.py inputs/ifgramStack.h5 --solver torch
+ifgram_inversion.py inputs/ifgramStack.h5 --solver torch --gpu-chunk-size 20000
+```
+
+`--gpu-chunk-size 0` (the default) auto-sizes the per-chunk pixel count from free VRAM; pass a positive integer to override.
+
+#### 2.2 via template file ####
+
+Adjust options in the template file:
+
+```cfg
+mintpy.networkInversion.solver       = torch  #[cpu / torch], auto for cpu
+mintpy.networkInversion.gpuChunkSize = auto   #[int >= 0], auto for 0 (auto-size from free VRAM)
+```
+
+and feed the template file to the script:
+
+```bash
+ifgram_inversion.py inputs/ifgramStack.h5 -t smallbaselineApp.cfg
+smallbaselineApp.py smallbaselineApp.cfg
+```
+
+#### 2.3 Testing using example data ####
+
+Download and run the FernandinaSenDT128 example data; then run with and without the GPU solver:
+
+```bash
+cd FernandinaSenDT128/mintpy
+ifgram_inversion.py inputs/ifgramStack.h5 -w no --solver cpu
+ifgram_inversion.py inputs/ifgramStack.h5 -w no --solver torch
+```
+
+The two outputs should agree to float32 round-off (RMS on the order of 1e-5).
+
+## 3. Behavior notes ##
+
++ **VRAM auto-sizing.** `gpuChunkSize = 0` (auto) probes free VRAM at runtime and chooses a per-chunk pixel count with a fixed headroom factor. Set an explicit integer to override (e.g. for reproducible chunking across hosts with different VRAM).
+
++ **Rank-deficient pixels.** Detected via `torch.linalg.cholesky_ex` info codes; their solution is set to zero so NaN/Inf never propagate downstream. A warning line reports the count per chunk.
+
++ **Per-pixel NaN observations.** Handled by zeroing the corresponding row weight, which is mathematically equivalent to dropping that row from the WLS system.
+
++ **No silent CPU fallback.** Selecting `solver = torch` on a host without a visible CUDA device raises immediately rather than silently falling back to CPU; this keeps performance regressions visible.
+
+## 4. Performance ##
+
+Benchmarks on FernandinaSenDT128 (RTX 5080, Blackwell sm_120, CUDA 12.8, PyTorch 2.11) are tracked in the sibling [`mintpy-benchmark`](https://github.com/s-sasaki-earthsea-wizard/mintpy-benchmark) repository:
+
++ [report_torch.md](https://github.com/s-sasaki-earthsea-wizard/mintpy-benchmark/blob/main/report_torch.md) — `cpu` vs `torch` end-to-end on the tutorial dataset
++ [report_solver_comparison.md](https://github.com/s-sasaki-earthsea-wizard/mintpy-benchmark/blob/main/report_solver_comparison.md) — lstsq vs Cholesky, numerical equivalence (RMS ~1e-5) and per-step speedup
++ [report_chunk_sweep.md](https://github.com/s-sasaki-earthsea-wizard/mintpy-benchmark/blob/main/report_chunk_sweep.md) — chunk-size sensitivity
++ [report_profile.md](https://github.com/s-sasaki-earthsea-wizard/mintpy-benchmark/blob/main/report_profile.md) — `torch.profiler` GPU kernel breakdown

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -247,6 +247,8 @@ mintpy.networkInversion.solver = torch
 ifgram_inversion.py inputs/ifgramStack.h5 --solver torch
 ```
 
+<p>See <a href="./gpu.md">gpu.md</a> for tuning, behavior notes, and benchmarks.</p>
+
 </details>
 </p>
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -194,6 +194,62 @@ Same as the <a href="#21-install-on-linux">instruction for Linux</a>, except for
 </details>
 </p>
 
+### 2.4 Optional: GPU acceleration via PyTorch CUDA ###
+
+<p>
+<details>
+<p><summary>Click to expand for more details</summary></p>
+
+<p>The <code>invert_network</code> step ships an opt-in GPU solver that solves the per-pixel WLS inversion as a batched normal-equation + Cholesky on a CUDA device via PyTorch. It is opt-in: the default <code>mintpy.networkInversion.solver = auto</code> resolves to <code>cpu</code>, so existing setups are unaffected. There is no silent CPU fallback — selecting <code>torch</code> without a visible CUDA device is a hard error.</p>
+
+<h4>a. Prerequisites</h4>
+
+<ul>
+<li>An NVIDIA GPU with a working CUDA driver</li>
+<li>MintPy installed from source in editable mode (Section 2 above)</li>
+</ul>
+
+<h4>b. Install the [gpu] extras</h4>
+
+<p>The <code>[gpu]</code> extras pull a CUDA-enabled PyTorch build. Pick the <code>cuXXX</code> wheel index that matches your CUDA toolkit version (see <a href="https://pytorch.org/get-started/locally/">pytorch.org</a> for the current list); for example, <code>cu121</code>, <code>cu124</code>, or <code>cu128</code>:</p>
+
+```bash
+python -m pip install -e ".[gpu]" \
+    --extra-index-url https://download.pytorch.org/whl/cu128
+```
+
+<p>If you use <a href="https://docs.astral.sh/uv/">uv</a> instead of <code>pip</code>, add <code>--index-strategy unsafe-best-match</code> to work around a stale <code>setuptools</code> pin in the PyTorch wheel index:</p>
+
+```bash
+uv pip install -e ".[gpu]" \
+    --extra-index-url https://download.pytorch.org/whl/cu128 \
+    --index-strategy unsafe-best-match
+```
+
+<h4>c. Verify</h4>
+
+```bash
+python -c "import torch; print(torch.cuda.is_available())"
+# expected: True
+```
+
+<h4>d. Enable</h4>
+
+<p>Set the template flag:</p>
+
+```cfg
+mintpy.networkInversion.solver = torch
+```
+
+<p>or pass it on the command line:</p>
+
+```bash
+ifgram_inversion.py inputs/ifgramStack.h5 --solver torch
+```
+
+</details>
+</p>
+
 ## 3. Post-Installation Setup ##
 
 #### a. ERA5 for tropospheric correction ####

--- a/requirements-gpu.txt
+++ b/requirements-gpu.txt
@@ -1,5 +1,4 @@
 # GPU acceleration deps (fork-only, not upstream).
 # Install with the PyTorch CUDA index, e.g.:
 #   uv pip install -e ".[gpu]" --extra-index-url https://download.pytorch.org/whl/cu128
-cupy-cuda12x
-torch
+torch>=2.11

--- a/src/mintpy/cli/ifgram_inversion.py
+++ b/src/mintpy/cli/ifgram_inversion.py
@@ -86,12 +86,15 @@ def create_parser(subparsers=None):
     solver.add_argument('--min-norm-phase', dest='minNormVelocity', action='store_false',
                         help=('Enable inversion with minimum-norm deformation phase,'
                               ' instead of the default minimum-norm deformation velocity.'))
-    solver.add_argument('--backend', dest='backend', default='cpu',
+    solver.add_argument('--solver', dest='solver', default='cpu',
                         choices={'cpu', 'torch'},
-                        help='lstsq backend: cpu (scipy, default) or torch '
-                             '(GPU-batched via torch.linalg.lstsq).')
+                        help='WLS solver: cpu (scipy.linalg.lstsq, default) '
+                             'or torch (CUDA-batched normal-equation + Cholesky via '
+                             'PyTorch). torch requires the [gpu] extras and a visible '
+                             'CUDA device; absence is a hard error. '
+                             'See docs/installation.md.')
     solver.add_argument('--gpu-chunk-size', dest='gpuChunkSize', type=int, default=0,
-                        help='pixels per GPU chunk for --backend=torch '
+                        help='pixels per GPU chunk for --solver=torch '
                              '(0=auto-size from free VRAM; default).')
     #solver.add_argument('--norm', dest='residualNorm', default='L2', choices=['L1', 'L2'],
     #                    help='Optimization method, L1 or L2 norm. (default: %(default)s).')
@@ -241,7 +244,7 @@ def read_template2inps(template_file, inps):
         elif value:
             if key in ['maskThreshold', 'minRedundancy']:
                 iDict[key] = float(value)
-            elif key in ['residualNorm', 'waterMaskFile', 'backend']:
+            elif key in ['residualNorm', 'waterMaskFile', 'solver']:
                 iDict[key] = value
             elif key in ['gpuChunkSize']:
                 iDict[key] = int(value)

--- a/src/mintpy/defaults/smallbaselineApp.cfg
+++ b/src/mintpy/defaults/smallbaselineApp.cfg
@@ -175,10 +175,14 @@ mintpy.unwrapError.bridgePtsRadius = auto  #[1-inf], auto for 50, half size of t
 mintpy.networkInversion.weightFunc      = auto #[var / fim / coh / no], auto for var
 mintpy.networkInversion.waterMaskFile   = auto #[filename / no], auto for waterMask.h5 or no [if not found]
 mintpy.networkInversion.minNormVelocity = auto #[yes / no], auto for yes, min-norm deformation velocity / phase
-## GPU acceleration of the per-pixel WLS solver (fork-only, opt-in):
-## a. cpu   - scipy.linalg.lstsq, per-pixel (default, upstream behavior)
-## b. torch - torch.linalg.lstsq batched on CUDA via the gels driver (assumes full-rank network)
-mintpy.networkInversion.backend         = auto #[cpu / torch], auto for cpu
+## WLS solver for the per-pixel network inversion (GPU path is opt-in):
+## a. cpu   - scipy.linalg.lstsq, per-pixel (default, original behavior)
+## b. torch - batched normal-equation + Cholesky on CUDA via PyTorch.
+##            Requires the [gpu] extras (CUDA-enabled torch build) and a
+##            visible CUDA device; absence is a hard error (no silent CPU
+##            fallback). The default 'auto' resolves to 'cpu', so existing
+##            setups are unaffected. See docs/installation.md.
+mintpy.networkInversion.solver          = auto #[cpu / torch], auto for cpu
 mintpy.networkInversion.gpuChunkSize    = auto #[int >= 0], auto for 0 (auto-size from free VRAM)
 
 ## mask options for unwrapPhase of each interferogram before inversion (recommend if weightFunct=no):

--- a/src/mintpy/defaults/smallbaselineApp_auto.cfg
+++ b/src/mintpy/defaults/smallbaselineApp_auto.cfg
@@ -70,7 +70,7 @@ mintpy.unwrapError.bridgePtsRadius   = 50
 mintpy.networkInversion.weightFunc       = var
 mintpy.networkInversion.waterMaskFile    = waterMask.h5
 mintpy.networkInversion.minNormVelocity  = yes
-mintpy.networkInversion.backend          = cpu
+mintpy.networkInversion.solver           = cpu
 mintpy.networkInversion.gpuChunkSize     = 0
 
 ## mask

--- a/src/mintpy/ifgram_inversion.py
+++ b/src/mintpy/ifgram_inversion.py
@@ -596,7 +596,7 @@ def get_design_matrix4std(stack_obj):
 def run_ifgram_inversion_patch(ifgram_file, box=None, ref_phase=None, obs_ds_name='unwrapPhase',
                                weight_func='var', water_mask_file=None, min_norm_velocity=True,
                                mask_ds_name=None, mask_threshold=0.4, min_redundancy=1.0, calc_cov=False,
-                               backend='cpu', gpu_chunk_size=0):
+                               solver='cpu', gpu_chunk_size=0):
     """Invert one patch of an ifgram stack into timeseries.
 
     Parameters: ifgram_file       - str, interferograms stack HDF5 file, e.g. ./inputs/ifgramStack.h5
@@ -611,10 +611,14 @@ def run_ifgram_inversion_patch(ifgram_file, box=None, ref_phase=None, obs_ds_nam
                 mask_threshold    - float, min coherence of pixels if mask_dataset_name='coherence'
                 min_redundancy    - float, the min number of ifgrams for every acquisition.
                 calc_cov          - bool, calculate the time series covariance matrix.
-                backend           - str, lstsq backend: 'cpu' (default) or 'torch'.
-                                    The 'torch' backend solves all valid pixels in one
-                                    batched, chunked GPU call via torch.linalg.lstsq.
-                gpu_chunk_size    - int, pixels per GPU chunk for backend='torch'.
+                solver            - str, WLS solver: 'cpu' (default,
+                                    scipy.linalg.lstsq per pixel) or 'torch'
+                                    (CUDA-batched normal-equation + Cholesky via
+                                    PyTorch). The 'torch' solver requires the
+                                    [gpu] extras and a visible CUDA device;
+                                    absence is a hard error (no silent CPU
+                                    fallback).
+                gpu_chunk_size    - int, pixels per GPU chunk for solver='torch'.
                                     0 (default) auto-sizes from free VRAM.
     Returns:    ts                - 3D array in size of (num_date, num_row, num_col)
                 ts_cov            - 4D array in size of (num_date, num_date, num_row, num_col) or None
@@ -811,9 +815,9 @@ def run_ifgram_inversion_patch(ifgram_file, box=None, ref_phase=None, obs_ds_nam
     # which is mathematically equivalent to dropping them from the LS system
     # for the full-rank case. Rank-deficient pixels (rare on real SBAS networks)
     # are not handled here; if encountered, NaN/Inf will propagate downstream.
-    if backend != 'cpu':
+    if solver != 'cpu':
         from mintpy.ifgram_inversion_gpu import estimate_timeseries_batch
-        print(f'estimating time-series via {backend} backend (batched, GPU)')
+        print(f'estimating time-series via {solver} solver (batched, GPU)')
         ts_sub, q_sub, n_sub = estimate_timeseries_batch(
             A=A, B=B,
             y=stack_obs[:, idx_pixel2inv],
@@ -825,7 +829,7 @@ def run_ifgram_inversion_patch(ifgram_file, box=None, ref_phase=None, obs_ds_nam
             min_redundancy=min_redundancy,
             inv_quality_name=inv_quality_name,
             chunk_size=gpu_chunk_size,
-            backend=backend,
+            solver=solver,
         )
         ts[:, idx_pixel2inv] = ts_sub
         inv_quality[idx_pixel2inv] = q_sub
@@ -1121,7 +1125,7 @@ def run_ifgram_inversion(inps):
         "mask_threshold"    : inps.maskThreshold,
         "min_redundancy"    : inps.minRedundancy,
         "calc_cov"          : inps.calcCov,
-        "backend"           : getattr(inps, 'backend', 'cpu'),
+        "solver"            : getattr(inps, 'solver', 'cpu'),
         "gpu_chunk_size"    : int(getattr(inps, 'gpuChunkSize', 0)),
     }
 

--- a/src/mintpy/ifgram_inversion_gpu.py
+++ b/src/mintpy/ifgram_inversion_gpu.py
@@ -19,7 +19,7 @@ never propagate.
 
 Per-pixel NaN observations are masked by zeroing the corresponding row
 weights, which is mathematically equivalent to dropping them from the WLS
-system. The CPU code path is unchanged when ``backend='cpu'`` and remains
+system. The CPU code path is unchanged when ``solver='cpu'`` and remains
 the numerical reference.
 """
 
@@ -33,7 +33,7 @@ except ImportError:
     HAS_TORCH = False
 
 
-SUPPORTED_BACKENDS = ('cpu', 'torch')
+SUPPORTED_SOLVERS = ('cpu', 'torch')
 
 # default chunk size when caller does not provide one and VRAM probing fails
 DEFAULT_CHUNK_SIZE = 20000
@@ -42,26 +42,26 @@ DEFAULT_CHUNK_SIZE = 20000
 VRAM_SAFETY = 0.4
 
 
-def is_backend_available(backend):
-    """Return True if the named GPU backend is importable and usable."""
-    if backend == 'cpu':
+def is_solver_available(solver):
+    """Return True if the named WLS solver is importable and usable."""
+    if solver == 'cpu':
         return True
-    if backend == 'torch':
+    if solver == 'torch':
         return HAS_TORCH and torch.cuda.is_available()
     return False
 
 
-def _get_torch_device(backend):
+def _get_torch_device(solver):
     if not HAS_TORCH:
         raise ImportError(
-            f"backend='{backend}' requires PyTorch. "
+            f"solver='{solver}' requires PyTorch. "
             "Install with `pip install -e \".[gpu]\" "
             "--extra-index-url https://download.pytorch.org/whl/cu128 "
             "--index-strategy unsafe-best-match`."
         )
     if not torch.cuda.is_available():
         raise RuntimeError(
-            f"backend='{backend}' requires CUDA, but torch.cuda.is_available() is False."
+            f"solver='{solver}' requires CUDA, but torch.cuda.is_available() is False."
         )
     return torch.device('cuda')
 
@@ -136,7 +136,7 @@ def estimate_timeseries_batch(
     min_redundancy=1.0,
     inv_quality_name='temporalCoherence',
     chunk_size=None,
-    backend='torch',
+    solver='torch',
     print_msg=True,
 ):
     """Batch GPU least-squares solver for the SBAS network inversion.
@@ -170,7 +170,7 @@ def estimate_timeseries_batch(
                           this, return zeros for all pixels.
         inv_quality_name: str. 'temporalCoherence' | 'residual' | 'no'.
         chunk_size:       int or None. Pixels per GPU chunk. None => auto.
-        backend:          str. 'torch' (only one implemented).
+        solver:           str. 'torch' (only one implemented).
         print_msg:        bool.
 
     Returns:
@@ -178,11 +178,11 @@ def estimate_timeseries_batch(
         inv_quality:      np.ndarray (num_pixel,) float32.
         num_inv_obs:      np.ndarray (num_pixel,) int16.
     """
-    if backend != 'torch':
+    if solver != 'torch':
         raise ValueError(
-            f"unsupported backend={backend!r}; choose from {SUPPORTED_BACKENDS}"
+            f"unsupported solver={solver!r}; choose from {SUPPORTED_SOLVERS}"
         )
-    device = _get_torch_device(backend)
+    device = _get_torch_device(solver)
 
     G = B if min_norm_velocity else A
     num_pair, num_unknown = G.shape
@@ -212,7 +212,7 @@ def estimate_timeseries_batch(
     num_chunk = (num_pixel + chunk_size - 1) // chunk_size
     if print_msg:
         mode = 'WLS' if weight_sqrt is not None else 'OLS'
-        print(f'estimating time-series via {backend} batched {mode} '
+        print(f'estimating time-series via {solver} batched {mode} '
               f'in {num_chunk} chunk(s) of up to {chunk_size} pixels ...')
 
     # move design matrix and tbase to GPU once (re-used across chunks)

--- a/tests/test_ifgram_inversion_gpu.py
+++ b/tests/test_ifgram_inversion_gpu.py
@@ -145,7 +145,7 @@ def test_wls_no_nan(network):
     gpu = estimate_timeseries_batch(
         A=A, B=B, y=y, tbase_diff=tbase_diff, weight_sqrt=w,
         min_norm_velocity=True,
-        chunk_size=64, backend='torch', print_msg=False,
+        chunk_size=64, solver='torch', print_msg=False,
     )
     assert_equivalent(cpu, gpu, ts_rel_tol=1e-5, tcoh_abs_tol=1e-5)
 
@@ -167,7 +167,7 @@ def test_wls_with_nan_redundant(network):
     gpu = estimate_timeseries_batch(
         A=A, B=B, y=y, tbase_diff=tbase_diff, weight_sqrt=w,
         min_norm_velocity=True,
-        chunk_size=32, backend='torch', print_msg=False,
+        chunk_size=32, solver='torch', print_msg=False,
     )
     assert_equivalent(cpu, gpu, ts_rel_tol=1e-4, tcoh_abs_tol=1e-4)
 
@@ -182,7 +182,7 @@ def test_ols_no_nan(network):
     gpu = estimate_timeseries_batch(
         A=A, B=B, y=y, tbase_diff=tbase_diff, weight_sqrt=None,
         min_norm_velocity=True,
-        chunk_size=32, backend='torch', print_msg=False,
+        chunk_size=32, solver='torch', print_msg=False,
     )
     assert_equivalent(cpu, gpu, ts_rel_tol=1e-5, tcoh_abs_tol=1e-5)
 
@@ -196,7 +196,7 @@ def test_min_norm_phase(network):
     gpu = estimate_timeseries_batch(
         A=A, B=B, y=y, tbase_diff=tbase_diff, weight_sqrt=w,
         min_norm_velocity=False,
-        chunk_size=32, backend='torch', print_msg=False,
+        chunk_size=32, solver='torch', print_msg=False,
     )
     assert_equivalent(cpu, gpu, ts_rel_tol=1e-5, tcoh_abs_tol=1e-5)
 
@@ -208,7 +208,7 @@ def test_chunk_size_invariance(network):
     y, w = synthesize_observations(A, B, num_pixel=64, nan_frac=0.03, seed=5)
     assert _all_pixels_full_rank(A, y)
     common = dict(A=A, B=B, y=y, tbase_diff=tbase_diff, weight_sqrt=w,
-                  min_norm_velocity=True, backend='torch', print_msg=False)
+                  min_norm_velocity=True, solver='torch', print_msg=False)
     ts_a, tcoh_a, nobs_a = estimate_timeseries_batch(chunk_size=16, **common)
     ts_b, tcoh_b, nobs_b = estimate_timeseries_batch(chunk_size=64, **common)
     np.testing.assert_allclose(ts_a, ts_b, rtol=1e-6, atol=1e-6)
@@ -217,11 +217,11 @@ def test_chunk_size_invariance(network):
 
 
 @requires_cuda
-def test_unsupported_backend_raises(network):
+def test_unsupported_solver_raises(network):
     A, B, tbase_diff = network
     y, w = synthesize_observations(A, B, num_pixel=8, seed=6)
-    with pytest.raises(ValueError, match='unsupported backend'):
+    with pytest.raises(ValueError, match='unsupported solver'):
         estimate_timeseries_batch(
             A=A, B=B, y=y, tbase_diff=tbase_diff, weight_sqrt=w,
-            backend='cupy', print_msg=False,
+            solver='cupy', print_msg=False,
         )


### PR DESCRIPTION
## Summary

Closes the docs side of [#5](https://github.com/s-sasaki-earthsea-wizard/MintPy/issues/5) and finishes the `backend` → `solver` rename so the user-visible surfaces (template key, CLI flag, Python kwarg) line up with the PyTorch terminology used in the GPU code path.

- **`docs/gpu.md` (new)** — modelled on `docs/dask.md`: motivation, install pointer, CLI / template usage with `solver = torch`, behaviour notes (VRAM auto-sizing, rank-deficient pixels, NaN handling, no silent CPU fallback), and links to the [`mintpy-benchmark`](https://github.com/s-sasaki-earthsea-wizard/mintpy-benchmark) reports.
- **`docs/installation.md` §2.4 (new)** — `[gpu]` extras install path with `--extra-index-url https://download.pytorch.org/whl/cu128` and the `--index-strategy unsafe-best-match` workaround for the stale `setuptools` pin in the PyTorch index, plus the `torch.cuda.is_available()` smoke test.
- **`docs/README.md`, `docs/dask.md`** — cross-links so the GPU and Dask perf stories find each other.
- **Rename `backend` → `solver`** across user surfaces — template key (`mintpy.networkInversion.solver`), CLI flag (`--solver {cpu,torch}`), Python kwarg, and the dispatcher in `ifgram_inversion.py` / `ifgram_inversion_gpu.py` / tests.
- **`requirements-gpu.txt`** — drop the unused `cupy` line (Issue [#4](https://github.com/s-sasaki-earthsea-wizard/MintPy/issues/4) closed cupy as out of scope) and pin `torch>=2.11` (the version under which the Phase 2 Cholesky path was developed and benched).

End-to-end verification of the documented install + run path on a brand-new venv, including the FernandinaSenDT128 tutorial through `smallbaselineApp.py` with `solver = torch`, is captured in the new wiki page [GPU Quick Start](https://github.com/s-sasaki-earthsea-wizard/MintPy/wiki/GPU-Quick-Start).

## Test plan

- [x] `uv venv --python 3.12 /tmp/issue5-venv` + `uv pip install -e ".[gpu]" --extra-index-url https://download.pytorch.org/whl/cu128 --index-strategy unsafe-best-match` from a clean state — installs base + GPU deps in one shot.
- [x] `torch.cuda.is_available()` returns `True` on RTX 5080 (Blackwell sm_120, CUDA 12.8, torch 2.11.0+cu128).
- [x] `smallbaselineApp.py FernandinaSenDT128.cfg` runs all 18 steps to "Normal end of smallbaselineApp processing!" with `mintpy.networkInversion.solver = torch`. `invert_network` log lines confirm GPU path:
  ```
  estimating time-series via torch solver (batched, GPU)
  GPU auto chunk_size = 19403 pixels (free VRAM 15.1 GiB)
  ```
- [x] CPU path unchanged — default `solver = auto` still resolves to `cpu`, no behaviour drift on the non-GPU code paths.