### PR TITLE
docs/gpu.md: update bench-report links after mintpy-benchmark restructure

### DIFF
--- a/docs/gpu.md
+++ b/docs/gpu.md
@@ -63,7 +63,7 @@ The two outputs should agree to float32 round-off (RMS on the order of 1e-5).
 
 Benchmarks on FernandinaSenDT128 (RTX 5080, Blackwell sm_120, CUDA 12.8, PyTorch 2.11) are tracked in the sibling [`mintpy-benchmark`](https://github.com/s-sasaki-earthsea-wizard/mintpy-benchmark) repository:
 
-+ [report_torch.md](https://github.com/s-sasaki-earthsea-wizard/mintpy-benchmark/blob/main/report_torch.md) — `cpu` vs `torch` end-to-end on the tutorial dataset
-+ [report_solver_comparison.md](https://github.com/s-sasaki-earthsea-wizard/mintpy-benchmark/blob/main/report_solver_comparison.md) — lstsq vs Cholesky, numerical equivalence (RMS ~1e-5) and per-step speedup
-+ [report_chunk_sweep.md](https://github.com/s-sasaki-earthsea-wizard/mintpy-benchmark/blob/main/report_chunk_sweep.md) — chunk-size sensitivity
-+ [report_profile.md](https://github.com/s-sasaki-earthsea-wizard/mintpy-benchmark/blob/main/report_profile.md) — `torch.profiler` GPU kernel breakdown
++ [report_torch.md](https://github.com/s-sasaki-earthsea-wizard/mintpy-benchmark/blob/main/reports/report_torch.md) — `cpu` vs `torch` end-to-end on the tutorial dataset
++ [report_solver_comparison.md](https://github.com/s-sasaki-earthsea-wizard/mintpy-benchmark/blob/main/reports/report_solver_comparison.md) — lstsq vs Cholesky, numerical equivalence (RMS ~1e-5) and per-step speedup
++ [report_chunk_sweep.md](https://github.com/s-sasaki-earthsea-wizard/mintpy-benchmark/blob/main/reports/report_chunk_sweep.md) — chunk-size sensitivity
++ [report_profile.md](https://github.com/s-sasaki-earthsea-wizard/mintpy-benchmark/blob/main/reports/report_profile.md) — `torch.profiler` GPU kernel breakdown


### PR DESCRIPTION
## Summary

- Fix the four `report_*.md` links in [docs/gpu.md](docs/gpu.md#L66-L69) so they resolve under the new `reports/` subdirectory created by [mintpy-benchmark#5](https://github.com/s-sasaki-earthsea-wizard/mintpy-benchmark/pull/5).
- Pure URL update: `blob/main/report_X.md` → `blob/main/reports/report_X.md`. No content / structural changes.

## Context

After the sibling repo's restructure was merged, the existing flat-layout links would 404. SHA-pinned permalinks elsewhere (e.g. the [Performance-Benchmarks wiki](https://github.com/s-sasaki-earthsea-wizard/MintPy/wiki/Performance-Benchmarks)) keep resolving via the SHA and need no edit.

Closes #12

## Test plan

- [x] `grep -nE 'mintpy-benchmark/blob/main/report_' docs/` returns nothing pointing at the flat layout
- [x] All four target files exist on `mintpy-benchmark/main` under `reports/` (verified via `gh api`)
- [x] Click through each updated link in the rendered PR diff and confirm the GitHub blob view loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)