### PR TITLE
gpu: introduce mintpy.gpu subpackage and migrate ifgram_inversion_gpu

### DIFF
--- a/src/mintpy/gpu/ifgram_inversion.py
+++ b/src/mintpy/gpu/ifgram_inversion.py
@@ -4,7 +4,7 @@
 # GPU-accelerated network inversion                        #
 ############################################################
 # Recommend import:
-#     from mintpy import ifgram_inversion_gpu as ifginv_gpu
+#     from mintpy.gpu import ifgram_inversion as gpu_ifginv
 
 
 """GPU-batched solver for the SBAS network inversion.

--- a/src/mintpy/ifgram_inversion.py
+++ b/src/mintpy/ifgram_inversion.py
@@ -816,7 +816,7 @@ def run_ifgram_inversion_patch(ifgram_file, box=None, ref_phase=None, obs_ds_nam
     # for the full-rank case. Rank-deficient pixels (rare on real SBAS networks)
     # are not handled here; if encountered, NaN/Inf will propagate downstream.
     if solver != 'cpu':
-        from mintpy.ifgram_inversion_gpu import estimate_timeseries_batch
+        from mintpy.gpu.ifgram_inversion import estimate_timeseries_batch
         print(f'estimating time-series via {solver} solver (batched, GPU)')
         ts_sub, q_sub, n_sub = estimate_timeseries_batch(
             A=A, B=B,

--- a/tests/test_gpu_ifgram_inversion.py
+++ b/tests/test_gpu_ifgram_inversion.py
@@ -1,4 +1,4 @@
-"""Numerical-equivalence tests for src/mintpy/ifgram_inversion_gpu.py.
+"""Numerical-equivalence tests for src/mintpy/gpu/ifgram_inversion.py.
 
 Compare the GPU-batched solver against the per-pixel CPU reference
 (scipy.linalg.lstsq via mintpy.ifgram_inversion.estimate_timeseries) on
@@ -11,12 +11,12 @@ import pytest
 
 torch = pytest.importorskip("torch")
 
+from mintpy.gpu.ifgram_inversion import estimate_timeseries_batch
 from mintpy.ifgram_inversion import estimate_timeseries
-from mintpy.ifgram_inversion_gpu import estimate_timeseries_batch
 
 requires_cuda = pytest.mark.skipif(
     not torch.cuda.is_available(),
-    reason="CUDA-capable GPU required for ifgram_inversion_gpu tests",
+    reason="CUDA-capable GPU required for mintpy.gpu.ifgram_inversion tests",
 )
 
 


### PR DESCRIPTION
## Summary

Pure refactor: relocate `src/mintpy/ifgram_inversion_gpu.py` into a new `src/mintpy/gpu/` subpackage. No behaviour change.

- `src/mintpy/ifgram_inversion_gpu.py` → `src/mintpy/gpu/ifgram_inversion.py`
- `tests/test_ifgram_inversion_gpu.py` → `tests/test_gpu_ifgram_inversion.py`
- New empty `src/mintpy/gpu/__init__.py`
- Import-path updates in 3 sites (dispatch caller in `ifgram_inversion.py:819`, docstring self-reference, test import) + CUDA-skip reason message

## Why

`src/mintpy/` currently holds 66 flat modules. As GPU acceleration extends to further steps (next target: `correct_topography`, tracked in #17), keeping new `*_gpu.py` modules flat would noise up the namespace. MintPy already uses subpackage conventions (`cli/`, `objects/`, `defaults/`, `legacy/`, `utils/`), so adding `gpu/` is consistent. `docs/gpu.md` aligns with the directory name.

## Out of scope

Extracting reusable helpers (`_get_torch_device`, `_auto_chunk_size`, etc.) into `src/mintpy/gpu/_common.py`. Deferred until the next GPU module surfaces concrete duplication (avoid premature DRY).

## Validation

- `pytest tests/test_gpu_ifgram_inversion.py`: **6 passed** on RTX 5080 / torch 2.11+cu128
- `CUDA_VISIBLE_DEVICES="" pytest tests/test_gpu_ifgram_inversion.py`: **6 skipped** with updated reason `CUDA-capable GPU required for mintpy.gpu.ifgram_inversion tests`
- Old import path `mintpy.ifgram_inversion_gpu` no longer resolves (`ModuleNotFoundError`)
- `pre-commit` hooks pass (13 hooks ran via commit gate, 3 skipped for no matching files)
- `pyproject.toml` unchanged: `[tool.setuptools.packages.find]` auto-discovery picks up `src/mintpy/gpu/`

End-to-end `smallbaselineApp.py` on FernandinaSenDT128 was intentionally out of scope per session agreement (unit-test parity is sufficient for a pure file-move + import rewrite).

## Upstream PR #1490 interaction

This branch does **not** touch `gpu_torch_solver` (the upstream PR branch). PR #1490 stays with the current flat layout. When/if #1490 merges, we will decide separately whether to surface the subpackage refactor upstream as (a) a standalone refactor PR, or (b) bundled with the next GPU step PR.

Closes #16

## Test plan

- [x] `pytest tests/test_gpu_ifgram_inversion.py` passes on CUDA box
- [x] `pytest tests/test_gpu_ifgram_inversion.py` skips cleanly with no CUDA
- [x] Old import path no longer resolves
- [x] `pre-commit` hooks pass on commit
- [x] Reviewer (user) merges; PR #17 (correct_topography GPU) branches from refactored `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)